### PR TITLE
Reset navigation state when returning from history

### DIFF
--- a/script.js
+++ b/script.js
@@ -32,15 +32,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  // Снимаем подсветку при возврате назад/вперёд
-  window.addEventListener('popstate', () => {
-    clearFocus();
+  function resetNavigationToRoot() {
+    showCategories();
     ensureNoActiveOnRoot();
-  });
-  window.addEventListener('pageshow', () => {
-    clearFocus();
-    ensureNoActiveOnRoot();
-  });
+  }
+
+  // Снимаем подсветку при возврате назад/вперёд и через BFCache
+  window.addEventListener('popstate', resetNavigationToRoot);
+  window.addEventListener('pageshow', resetNavigationToRoot);
 
   // === 1) Загрузка каталога ================================================
   async function fetchCatalog() {


### PR DESCRIPTION
## Summary
- reset the navigation state to the root when returning via popstate or pageshow so highlights are cleared

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d14dcd2cb88328b6765f3ea08e6595