### PR TITLE
Prevent root category button highlight on return

### DIFF
--- a/script.js
+++ b/script.js
@@ -32,14 +32,39 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function hardClearRootHighlight() {
+    const nav = navEl();
+    if (!nav || nav.dataset.level !== 'root') return;
+
+    ensureNoActiveOnRoot();
+
+    nav.querySelectorAll('button').forEach(btn => {
+      btn.style.background = '#222';
+      btn.style.color = '#ffd700';
+    });
+  }
+
   function resetNavigationToRoot() {
     showCategories();
-    ensureNoActiveOnRoot();
   }
 
   // Снимаем подсветку при возврате назад/вперёд и через BFCache
-  window.addEventListener('popstate', resetNavigationToRoot);
-  window.addEventListener('pageshow', resetNavigationToRoot);
+  window.addEventListener('popstate', () => {
+    resetNavigationToRoot();
+    hardClearRootHighlight();
+  });
+  window.addEventListener('pageshow', () => {
+    resetNavigationToRoot();
+    hardClearRootHighlight();
+  });
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      hardClearRootHighlight();
+    }
+  });
+  window.addEventListener('pagehide', () => {
+    hardClearRootHighlight();
+  });
 
   // === 1) Загрузка каталога ================================================
   async function fetchCatalog() {
@@ -54,8 +79,6 @@ document.addEventListener('DOMContentLoaded', () => {
     currentSubcategory = null;
     document.getElementById('products').innerHTML = '';
     renderCategoryButtons();
-    clearFocus();
-    ensureNoActiveOnRoot();
   }
 
   // === 3) Рендер категорий/подкатегорий ====================================
@@ -71,6 +94,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = document.createElement('button');
         btn.textContent = cat.name;
         btn.classList.remove('active');
+        btn.style.background = '#222';
+        btn.style.color = '#ffd700';
 
         btn.onclick = e => {
           e.stopPropagation();
@@ -84,7 +109,7 @@ document.addEventListener('DOMContentLoaded', () => {
         nav.appendChild(btn);
       });
 
-      ensureNoActiveOnRoot();
+      hardClearRootHighlight();
       return;
     }
 

--- a/style.css
+++ b/style.css
@@ -77,6 +77,15 @@ nav#categories button:hover {
   color: #ffd700 !important;        /* базовый текст */
 }
 
+@media (hover: hover) {
+  #categories[data-level="root"] button:hover,
+  #categories[data-level="root"] button:focus,
+  #categories[data-level="root"] button:active {
+    background: #222 !important;
+    color: #ffd700 !important;
+  }
+}
+
 /* Глушим залипание фокуса (desktop + mobile) */
 nav#categories button:focus {
   outline: none;


### PR DESCRIPTION
## Summary
- add CSS overrides to suppress root button hover/focus/active states on hover-capable devices
- introduce `hardClearRootHighlight` and connect it to navigation/page lifecycle events to drop focus on root buttons
- render root category buttons with explicit base colors to avoid inherited styling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d15c9be5ec8328a46fb4dec19f312e